### PR TITLE
Replace removed Position property with LinesOnlyPosition

### DIFF
--- a/codeclimate-govet.go
+++ b/codeclimate-govet.go
@@ -66,7 +66,7 @@ func main() {
 						Categories:        []string{"Bug Risk"},
 						Location: &engine.Location{
 							Path: strings.SplitAfter(path, rootPath)[1],
-							Lines: &engine.Position{
+							Lines: &engine.LinesOnlyPosition{
 								Begin: lineNo,
 								End:   lineNo,
 							},


### PR DESCRIPTION
Due to the changes introduced in the [pull request](https://github.com/codeclimate/cc-engine-go/pull/1) the `Position` property on `engine` object is not longer present. This caused errors while building docker image.
