### PR TITLE
Use 50,000 remediation points

### DIFF
--- a/codeclimate-govet.go
+++ b/codeclimate-govet.go
@@ -62,7 +62,7 @@ func main() {
 						Type:              "issue",
 						Check:             "GoVet/BugRisk",
 						Description:       strings.Join(pieces[2:], ":"),
-						RemediationPoints: 500,
+						RemediationPoints: 50000,
 						Categories:        []string{"Bug Risk"},
 						Location: &engine.Location{
 							Path: strings.SplitAfter(path, rootPath)[1],


### PR DESCRIPTION
500 is _much_ too low. Spec says 50,000 is appropriate for trivial
issues like missing semicolons, so it seems like an appropriate baseline
here.
