### PR TITLE
Only print debugging output for exceptional cases

### DIFF
--- a/codeclimate-govet.go
+++ b/codeclimate-govet.go
@@ -28,7 +28,8 @@ func main() {
 		cmd := exec.Command("go", "tool", "vet", path)
 
 		out, err := cmd.CombinedOutput()
-		if err != nil {
+
+		if err != nil && err.Error() != "exit status 1" {
 			fmt.Fprintf(os.Stderr, "Error analyzing path: %v\n", path)
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 
@@ -36,10 +37,7 @@ func main() {
 				s := string(out[:])
 				fmt.Fprintf(os.Stderr, "Govet output: %v\n", s)
 			}
-		}
 
-
-		if err != nil && err.Error() != "exit status 1" {
 			return
 		}
 


### PR DESCRIPTION
I noticed that the logging we recently introduced may be too eager. It
seems that it prints each issue to stderr and also to stdout. With this
change, it only prints to stderr when the analysis fails in an
unexpected way, where we would rather `return` to bail out of analysis
earlier than continue.

I'm wondering if we should also `os.Exit(1)` here to make sure the user
is aware that something has gone wrong.

Example build with more output than expected: https://codeclimate.com/repos/57f406791cee57006a005302/builds/3

cc @ABaldwinHunter 
