### PR TITLE
Fix command to use correct command

### DIFF
--- a/codeclimate-govet.go
+++ b/codeclimate-govet.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	for _, path := range analysisFiles {
-		cmd := exec.Command("go", "tool", "vet", path)
+		cmd := exec.Command("go", "vet", path)
 
 		out, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
Fixes error with the go vet command: 
```
Unexpected format for the following output: vet: invoking "go tool vet" directly is unsupported; use "go vet"
```