### PR TITLE
Update dockerfile to Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-ARG BASE=1.16.5-alpine3.14
+ARG BASE=1.16.5-buster
 FROM golang:${BASE} as build
 
 WORKDIR /usr/src/app
 
 COPY engine.json ./engine.json.template
-RUN apk add --no-cache jq
+RUN apt-get update && apt-get install -y jq
 RUN export go_version=$(go version | cut -d ' ' -f 3) && \
     cat engine.json.template | jq '.version = .version + "/" + env.go_version' > ./engine.json
 
 COPY codeclimate-govet.go go.mod go.sum ./
-RUN apk add --no-cache git
+# RUN apk add --no-cache git
 RUN go build -o codeclimate-govet .
 
 FROM golang:${BASE}
@@ -18,13 +18,10 @@ LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 WORKDIR /usr/src/app
 
-RUN adduser -u 9000 -D app
-
 COPY --from=build /usr/src/app/engine.json /
 COPY --from=build /usr/src/app/codeclimate-govet ./
 
-USER app
-
 VOLUME /code
+WORKDIR /code
 
 CMD ["/usr/src/app/codeclimate-govet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=1.13.1-alpine3.10
+ARG BASE=1.16.5-alpine3.14
 FROM golang:${BASE} as build
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN export go_version=$(go version | cut -d ' ' -f 3) && \
     cat engine.json.template | jq '.version = .version + "/" + env.go_version' > ./engine.json
 
 COPY codeclimate-govet.go go.mod go.sum ./
-# RUN apk add --no-cache git
+
 RUN go build -o codeclimate-govet .
 
 FROM golang:${BASE}
@@ -17,7 +17,6 @@ FROM golang:${BASE}
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 WORKDIR /usr/src/app
-
 COPY --from=build /usr/src/app/engine.json /
 COPY --from=build /usr/src/app/codeclimate-govet ./
 

--- a/codeclimate-govet.go
+++ b/codeclimate-govet.go
@@ -1,20 +1,30 @@
 package main
 
 import (
-	"github.com/codeclimate/cc-engine-go/engine"
-	"strings"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
-	"fmt"
+	"strings"
+
+	"github.com/codeclimate/cc-engine-go/engine"
 )
 
 func main() {
-	rootPath := "/code/"
+	rootPath, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting working directory: %v\n", err)
+		os.Exit(1)
+	}
 
 	config, err := engine.LoadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := exec.Command("go", "mod", "download").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error downloading dependencies: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/codeclimate-community/codeclimate-govet
 
-go 1.13
+go 1.16
 
 require github.com/codeclimate/cc-engine-go v0.0.0-20160217183426-55f9c825e2a9


### PR DESCRIPTION
Go 1.16 introduces the `embed` package which is currently causing `go vet` failures.
This PR updates to use the latest stable version of Go (1.16.5) so that the `go vet` tool is up-to-date 

This also updates the docker container to use buster rather than alpine so that it contains the require applications to download and module dependencies (git and gcc)

In Go 1.16, `go xxx` commands will no longer download any missing dependencies so we have to explicitly call `go mod download` to make sure we have all the dependencies to run analysis.

I've also applied a fix for this to run in any directory not just `/code/` and appended to the dockerfile to set the working directory to `/code/` instead.

fixes #25 