### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag codeclimate/codeclimate-govet \
-              us.gcr.io/code-climate/codeclimate-govet:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-govet:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2
@@ -38,6 +37,7 @@ workflows:
     jobs:
       - build
       - release_images:
+          context: Quality
           requires:
             - build
           filters:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-govet
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --tag "$(IMAGE_NAME)" .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: image
+.PHONY: image release
 
 IMAGE_NAME ?= codeclimate/codeclimate-govet
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --tag "$(IMAGE_NAME)" .
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-govet:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-govet:$(RELEASE_TAG)


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.